### PR TITLE
Add PHP version matrix for GitHub Actions CI

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -12,12 +12,19 @@ jobs:
     env:
       PHP_EXTENSIONS: none, curl, dom, json, libxml, mbstring, openssl, phar, soap, tokenizer, xml, xmlwriter
       PHP_INI_VALUES: memory_limit=-1, assert.exception=1, zend.assertions=1, error_reporting=-1, log_errors_max_len=0, display_errors=On
+    strategy:
+      matrix:
+        php-version:
+          - '8.0'
+          - '8.1'
+          - '8.2'
+          - '8.3'
     steps:
       - uses: actions/checkout@v3
       - name: Install PHP with extensions
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ env.PHP_VERSION }}
+          php-version: ${{ matrix.php-version }}
           extensions: ${{ env.PHP_EXTENSIONS }}
           ini-values: ${{ env.PHP_INI_VALUES }}
           tools: composer:v2


### PR DESCRIPTION
READMEに「PHP8.0～PHP8.3での使用を推奨します。」とあったので GitHub Actions での CI に PHP 8.0 と PHP 8.2、PHP 8.3 を追加しています。

CIでチェックするPHPのバージョンを増やしておくことで各バージョン毎でのテストをCI上で確認できるので便利だと思います。
またこのPRをマージされるかなどはお任せします。